### PR TITLE
feat: added zkey 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ You will have to check the latest number that hasn't been used yet by inspecting
 You would run the following command. If you're a kind anon, then change the numbers in the readme when you're done.
 ```
 snarkjs zkc \
-  ./zkeys/withdraw_from_subset_simple_0006.zkey \
-  ./zkeys/withdraw_from_subset_simple_0007.zkey
+  ./zkeys/withdraw_from_subset_simple_0007.zkey \
+  ./zkeys/withdraw_from_subset_simple_0008.zkey
 ```
 Do this from the root directory to generate the next contribution. Then, commit and push to your fork. We'll use a random blockhash for the beacon portion of the ceremony.
 


### PR DESCRIPTION
Happy to contribute! 

When doing snarkjs zkv, an error is thrown, not sure if this is standard.

I'm on mac, using snarkjs@0.5.0
circom compiler 2.0.3

```
$ snarkjs zkv \
  ./build/withdraw_from_subset_simple.r1cs \
  ./ptau/powersOfTau28_hez_final_14.ptau \
  ./zkeys/withdraw_from_subset_simple_0007.zkey
[INFO]  snarkJS: Reading r1cs
[INFO]  snarkJS: Reading tauG1
[INFO]  snarkJS: Reading tauG2
[INFO]  snarkJS: Reading alphatauG1
[INFO]  snarkJS: Reading betatauG1
[INFO]  snarkJS: Circuit hash:
		85228df9 7eff386d e76a4e08 82e4d68d
		0f699a86 e161e1e0 f939eb26 2af74e4b
		23f6a075 1973dc55 54a088a7 ac286188
		9ecb5050 3d7a2dc8 a8a832b8 3c1ae8ab
[ERROR] snarkJS: Coeffs section is not identical
```